### PR TITLE
Camelize and clean up default v-bind expressions, attempt 2

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -716,6 +716,11 @@ function compileDirectives (attrs, options) {
         pushDir(dirName, internalDirectives[dirName])
       } else {
         arg = dirName
+        // support for shorthand expression (#2843)
+        // <div v-bind:content> => <div v-bind:content="content">
+        if (!value) {
+          value = dirName
+        }
         pushDir('bind', publicDirectives.bind)
       }
     } else

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -14,7 +14,8 @@ import {
   checkComponentAttr,
   findRef,
   defineReactive,
-  getAttr
+  getAttr,
+  camelize
 } from '../util/index'
 
 // special binding prefixes
@@ -719,7 +720,7 @@ function compileDirectives (attrs, options) {
         // support for shorthand expression (#2843)
         // <div v-bind:content> => <div v-bind:content="content">
         if (!value) {
-          value = dirName
+          value = camelize(dirName, true)
         }
         pushDir('bind', publicDirectives.bind)
       }

--- a/src/util/lang.js
+++ b/src/util/lang.js
@@ -174,8 +174,9 @@ export function stripQuotes (str) {
  */
 
 var camelizeRE = /-(\w)/g
-export function camelize (str) {
-  return str.replace(camelizeRE, toUpper)
+var camelizeCleanupRE = /\W+(\w)?/
+export function camelize (str, cleanup) {
+  return str.replace(cleanup ? camelizeCleanupRE : camelizeRE, toUpper)
 }
 
 function toUpper (_, c) {

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -112,6 +112,7 @@ describe('Compile', function () {
     el.setAttribute(':class', 'a')
     el.setAttribute(':style', 'b')
     el.setAttribute(':title', 'c')
+    el.setAttribute(':content', '')
 
     // The order of setAttribute is not guaranteed to be the same with
     // the order of attribute enumberation, therefore we need to save
@@ -135,6 +136,13 @@ describe('Compile', function () {
         expression: 'c',
         arg: 'title',
         def: publicDirectives.bind
+      },
+      ':content': {
+        name: 'bind',
+        attr: ':content',
+        expression: 'content',
+        arg: 'content',
+        def: publicDirectives.bind
       }
     }
     var expects = [].map.call(el.attributes, function (attr) {
@@ -143,7 +151,7 @@ describe('Compile', function () {
 
     var linker = compile(el, Vue.options)
     linker(vm, el)
-    expect(vm._bindDir.calls.count()).toBe(3)
+    expect(vm._bindDir.calls.count()).toBe(4)
 
     expects.forEach(function (e, i) {
       var args = vm._bindDir.calls.argsFor(i)

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -113,6 +113,8 @@ describe('Compile', function () {
     el.setAttribute(':style', 'b')
     el.setAttribute(':title', 'c')
     el.setAttribute(':content', '')
+    el.setAttribute(':data-content', '')
+    el.setAttribute(':ns:attr', '')
 
     // The order of setAttribute is not guaranteed to be the same with
     // the order of attribute enumberation, therefore we need to save
@@ -143,6 +145,20 @@ describe('Compile', function () {
         expression: 'content',
         arg: 'content',
         def: publicDirectives.bind
+      },
+      ':data-content': {
+        name: 'bind',
+        attr: ':data-content',
+        expression: 'dataContent',
+        arg: 'data-content',
+        def: publicDirectives.bind
+      },
+      ':ns:attr': {
+        name: 'bind',
+        attr: ':ns:attr',
+        expression: 'nsAttr',
+        arg: 'ns:attr',
+        def: publicDirectives.bind
       }
     }
     var expects = [].map.call(el.attributes, function (attr) {
@@ -151,7 +167,7 @@ describe('Compile', function () {
 
     var linker = compile(el, Vue.options)
     linker(vm, el)
-    expect(vm._bindDir.calls.count()).toBe(4)
+    expect(vm._bindDir.calls.count()).toBe(6)
 
     expects.forEach(function (e, i) {
       var args = vm._bindDir.calls.argsFor(i)


### PR DESCRIPTION
I see you got started while I got distracted, but this also handles namespaces and the like.